### PR TITLE
Only change the current item's color

### DIFF
--- a/src/components/header/style.scss
+++ b/src/components/header/style.scss
@@ -71,7 +71,7 @@ $md-header-width: 720px;
         height: 100%;
         font-size: 14px;
 
-        &.current {
+        li.current {
           background: #5e6a71;
           filter: brightness(1.1);
 


### PR DESCRIPTION
This changes the look of the sub menu from this:
![image](https://user-images.githubusercontent.com/561438/149408822-041e4c7f-8405-491b-a6fe-c890abbda302.png)

to this:
![image](https://user-images.githubusercontent.com/561438/149408760-d82f20a3-bbd0-48b1-b34f-f2293d160b71.png)

Such that only the active item is darkened.